### PR TITLE
Added missing build instruction, improved clean.sh and added script to launch a local FrameIT server

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,1 +1,1 @@
-../MMT/deploy/run-file build.msl
+../MMT/deploy/run-file.bat build.msl

--- a/build.msl
+++ b/build.msl
@@ -2,5 +2,6 @@ mathpath archive .
 
 file MathHub/MMT/urtheories/build.msl
 file MathHub/MMT/LFX/build.msl
+file MathHub/MitM/Foundation/build.msl
 file MathHub/MitM/core/build.msl
 file MathHub/FrameIT/frameworld/build.msl

--- a/clean.cmd
+++ b/clean.cmd
@@ -1,1 +1,4 @@
 git submodule foreach "git clean -fdx ; git reset --hard"
+
+@echo -------------------------------
+@echo Note: the bash version of this script "clean.sh" can also remove commited build artefacts, resulting in a real clean build.

--- a/clean.sh
+++ b/clean.sh
@@ -1,4 +1,9 @@
+#!/bin/sh
 git submodule foreach "
     git clean -fdx
     git reset --hard
 "
+
+echo
+echo "Removing all commited build artefacts:"
+find '(' -type d '(' -name "bin" -o -name "content" -o -name "errors" -o -name "narration" -o -name "relational" -o -name "logaux" ')' -o -type f -name "build.html" ')' -print -exec rm -r {} +

--- a/launch-frameit-server.cmd
+++ b/launch-frameit-server.cmd
@@ -1,0 +1,1 @@
+java -jar ..\MMT\deploy\frameit.jar -bind :8085 -archive-root .

--- a/launch-frameit-server.sh
+++ b/launch-frameit-server.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 java -jar ../MMT/deploy/frameit.jar -bind :8085 -archive-root .

--- a/launch-frameit-server.sh
+++ b/launch-frameit-server.sh
@@ -1,0 +1,1 @@
+java -jar ../MMT/deploy/frameit.jar -bind :8085 -archive-root .

--- a/update-to-version-at-date.sh
+++ b/update-to-version-at-date.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # ./update-to-version-at-date.sh 3 month ago
 # ./update-to-version-at-date.sh 22.12.2023 12:32
 git submodule foreach "git log --all --oneline --format=format:%H --before '$*'  | head -n1 | xargs git checkout"


### PR DESCRIPTION
Improved the bash version of the clean script (clean.sh) to also remove commited build artefacts.
This way we can have real clean builds and don't reuse maybe outdated build artefacts from the MathHub repositories.

Doing the same for the windows clean.cmd would have been more complicated. But the git-bash can be used to run the unix version of the script on windows.

While I was testing this improved clean.sh script, I noticed that we are missing a build instruction in the archives repo that builds MitM/Foundation. This pull request also adds this missing build instruction.

I also added my launch-frameit-server.sh script.